### PR TITLE
Comment out load folders version refferences

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -2,7 +2,7 @@
 <loadFolders>
 	<v1.4>
 		<!--version specific -->
-		<li>1.4</li>
+		<!-- <li>1.4</li> as folder is deleted, commented out -->
 		
 		<!-- non version specific -->
 		<li>/</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -18,7 +18,7 @@
 	</v1.5>
 	<v1.6>
 		<!--version specific -->
-		<li>1.6</li>
+		<!-- <li>1.6</li> as folder is deleted, commented out -->
 		
 		<!-- non version specific -->
 		<li>Common</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -10,7 +10,7 @@
 	</v1.4>
 	<v1.5>
 		<!--version specific -->
-		<li>1.5</li>
+		<!-- <li>1.5</li> as folder is deleted, commented out-->
 		
 		<!-- non version specific -->
 		<li>Common</li>


### PR DESCRIPTION
as the folders for 1.4, 1.5, and 1.6 have been deleted, I commented out the part refferencing them.

that's in case rimworld sees it, tries to refference it, and, well, who knows.